### PR TITLE
Update plugin to discover all the Dockerfiles present in CWD by default. Closes #6

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,7 +16,7 @@ builds:
       - amd64
       - arm64
     ignore:
-      - goos: darwin # docs suggest that darwin arm64 should compile, but doesnt...
+      - goos: darwin # docs suggest that darwin arm64 should compile, but doesn't...
         goarch: arm64
 
     id: "steampipe-docker"

--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ Install the plugin with [Steampipe](https://steampipe.io):
 steampipe plugin install docker
 ```
 
+Configure your [config file](https://hub.steampipe.io/plugins/turbot/docker#configuration) to include directories with Docker files. If no directory is specified, the current working directory will be used.
+
+Run steampipe:
+
+```shell
+steampipe query
+```
+
 Run a query:
 
 ```sql
@@ -28,7 +36,7 @@ from
 where
   path = '/my/Dockerfile'
 order by
-  start_line
+  start_line;
 ```
 
 ## Developing

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Install the plugin with [Steampipe](https://steampipe.io):
 steampipe plugin install docker
 ```
 
-Configure your [config file](https://hub.steampipe.io/plugins/turbot/docker#configuration) to include directories with Docker files. If no directory is specified, the current working directory will be used.
+Configure your [config file](https://hub.steampipe.io/plugins/turbot/docker#configuration) to include directories with Dockerfiles. If no directory is specified, the current working directory will be used.
 
 Run steampipe:
 

--- a/config/docker.spc
+++ b/config/docker.spc
@@ -13,7 +13,7 @@ connection "docker" {
   #  - "/path/to/dir/*.dockerfile" matches all Dockerfiles in a specific directory
   #  - "/path/to/dir/Dockerfile" matches a specific Dockerfile
 
-  # If paths includes "*", all files (including non-Docker files) in
+  # If paths includes "*", all files (including non-Dockerfiles) in
   # the CWD will be matched, which may cause errors if incompatible file types exist
 
   # Defaults to CWD

--- a/config/docker.spc
+++ b/config/docker.spc
@@ -1,12 +1,23 @@
 connection "docker" {
   plugin = "docker"
 
-  # Paths is a list of locations to search for Dockerfiles by default.
-  # Wildcards are supported per https://golang.org/pkg/path/filepath/#Match
-  # Exact file paths can have any name. Wildcard based matches must either
-  # have a name of Dockerfile (e.g. Dockerfile, Dockerfile.example) or an
-  # .dockerfile extension (e.g. nginx.dockerfile).
-  # paths = [ "/path/to/dir/*", "/path/to/exact/custom-dockerfile-name" ]
+  # Paths is a list of locations to search for Dockerfiles
+  # All paths are resolved relative to the current working directory (CWD)
+  # Wildcard based searches are supported, including recursive searches
+
+  # For example:
+  #  - "*.dockerfile" matches all Docker files in the CWD
+  #  - "**/*.dockerfile" matches all Docker files in the CWD and all sub-directories
+  #  - "../*.dockerfile" matches all Docker files in the CWD's parent directory
+  #  - "Dockerfile" matches all Docker files named "Dockerfile" in the current CWD
+  #  - "/path/to/dir/*.dockerfile" matches all Docker files in a specific directory
+  #  - "/path/to/dir/Dockerfile" matches a specific file
+
+  # If paths includes "*", all files (including non-Docker files) in
+  # the current CWD will be matched, which may cause errors if incompatible filetypes exist
+
+  # Defaults to CWD
+  paths = [ "Dockerfile", "*.dockerfile" ]
 
   # Optional docker engine configuration.
   # host        = "tcp://192.168.59.103:2376"

--- a/config/docker.spc
+++ b/config/docker.spc
@@ -6,15 +6,15 @@ connection "docker" {
   # Wildcard based searches are supported, including recursive searches
 
   # For example:
-  #  - "*.dockerfile" matches all Docker files in the CWD
-  #  - "**/*.dockerfile" matches all Docker files in the CWD and all sub-directories
-  #  - "../*.dockerfile" matches all Docker files in the CWD's parent directory
-  #  - "Dockerfile" matches all Docker files named "Dockerfile" in the current CWD
-  #  - "/path/to/dir/*.dockerfile" matches all Docker files in a specific directory
-  #  - "/path/to/dir/Dockerfile" matches a specific file
+  #  - "*.dockerfile" matches all Dockerfiles in the CWD
+  #  - "**/*.dockerfile" matches all Dockerfiles in the CWD and all sub-directories
+  #  - "../*.dockerfile" matches all Dockerfiles in the CWD's parent directory
+  #  - "Dockerfile" matches all Dockerfiles named "Dockerfile" in the CWD
+  #  - "/path/to/dir/*.dockerfile" matches all Dockerfiles in a specific directory
+  #  - "/path/to/dir/Dockerfile" matches a specific Dockerfile
 
   # If paths includes "*", all files (including non-Docker files) in
-  # the current CWD will be matched, which may cause errors if incompatible filetypes exist
+  # the CWD will be matched, which may cause errors if incompatible file types exist
 
   # Defaults to CWD
   paths = [ "Dockerfile", "*.dockerfile" ]

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ select
 from
   dockerfile_cmd
 where
-  path = '/my/Dockerfile'
+  path = '/my/Dockerfile';
 ```
 
 ```
@@ -66,11 +66,34 @@ Installing the latest docker plugin will create a config file (`~/.steampipe/con
 ```hcl
 connection "docker" {
   plugin = "docker"
-  paths = [ "/path/to/Dockerfile", "/path/to/many/dockerfiles/*" ]
+
+  # Paths is a list of locations to search for Dockerfiles
+  # All paths are resolved relative to the current working directory (CWD)
+  # Wildcard based searches are supported, including recursive searches
+
+  # For example:
+  #  - "*.dockerfile" matches all Docker files in the CWD
+  #  - "**/*.dockerfile" matches all Docker files in the CWD and all sub-directories
+  #  - "../*.dockerfile" matches all Docker files in the CWD's parent directory
+  #  - "Dockerfile" matches all Docker files named "Dockerfile" in the current CWD
+  #  - "/path/to/dir/*.dockerfile" matches all Docker files in a specific directory
+  #  - "/path/to/dir/Dockerfile" matches a specific file
+
+  # If paths includes "*", all files (including non-Docker files) in
+  # the current CWD will be matched, which may cause errors if incompatible filetypes exist
+
+  # Defaults to CWD
+  paths = [ "Dockerfile", "*.dockerfile" ]
+
+  # Optional docker engine configuration.
+  # host        = "tcp://192.168.59.103:2376"
+  # cert_path   = "/path/to/my-cert"
+  # api_version = "1.41"
+  # tls_verify  = true
 }
 ```
 
-- `paths` - A list of directory paths to search for Dockerfiles. Paths may [include wildcards](https://pkg.go.dev/path/filepath#Match). File matches must start with `Dockerfile` or have an extension of `.dockerfile`.
+- `paths` - A list of directory paths to search for Dockerfiles. Paths are resolved relative to the current working directory. Paths may [include wildcards](https://pkg.go.dev/path/filepath#Match) and also support `**` for recursive matching. Defaults to the current working directory.
 - `host` - Location of the docker engine endpoint. Defaults to `DOCKER_HOST` env var.
 - `api_version` - API version to use. Defaults to `DOCKER_API_VERSION` env var.
 - `cert_path` - Path to a custom TLS certificate. Defaults to `DOCKER_CERT_PATH` env var.

--- a/docs/index.md
+++ b/docs/index.md
@@ -72,15 +72,15 @@ connection "docker" {
   # Wildcard based searches are supported, including recursive searches
 
   # For example:
-  #  - "*.dockerfile" matches all Docker files in the CWD
-  #  - "**/*.dockerfile" matches all Docker files in the CWD and all sub-directories
-  #  - "../*.dockerfile" matches all Docker files in the CWD's parent directory
-  #  - "Dockerfile" matches all Docker files named "Dockerfile" in the current CWD
-  #  - "/path/to/dir/*.dockerfile" matches all Docker files in a specific directory
+  #  - "*.dockerfile" matches all Dockerfiles in the CWD
+  #  - "**/*.dockerfile" matches all Dockerfiles in the CWD and all sub-directories
+  #  - "../*.dockerfile" matches all Dockerfiles in the CWD's parent directory
+  #  - "Dockerfile" matches all Dockerfiles named "Dockerfile" in the CWD
+  #  - "/path/to/dir/*.dockerfile" matches all Dockerfiles in a specific directory
   #  - "/path/to/dir/Dockerfile" matches a specific file
 
-  # If paths includes "*", all files (including non-Docker files) in
-  # the current CWD will be matched, which may cause errors if incompatible filetypes exist
+  # If paths includes "*", all files (including non-Dockerfiles) in
+  # the CWD will be matched, which may cause errors if incompatible file types exist
 
   # Defaults to CWD
   paths = [ "Dockerfile", "*.dockerfile" ]
@@ -93,7 +93,7 @@ connection "docker" {
 }
 ```
 
-- `paths` - A list of directory paths to search for Dockerfiles. Paths are resolved relative to the current working directory. Paths may [include wildcards](https://pkg.go.dev/path/filepath#Match) and also support `**` for recursive matching. Defaults to the current working directory.
+- `paths` - A list of directory paths to search for Dockerfiles. Paths are resolved relative to the current working directory. Paths may [include wildcards](https://pkg.go.dev/path/filepath#Match) and also supports `**` for recursive matching. Defaults to the current working directory.
 - `host` - Location of the docker engine endpoint. Defaults to `DOCKER_HOST` env var.
 - `api_version` - API version to use. Defaults to `DOCKER_API_VERSION` env var.
 - `cert_path` - Path to a custom TLS certificate. Defaults to `DOCKER_CERT_PATH` env var.

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/turbot/steampipe-plugin-docker
 go 1.17
 
 require (
+	github.com/bmatcuk/doublestar v1.3.4
 	github.com/docker/docker v20.10.7+incompatible
 	github.com/moby/buildkit v0.8.3
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -161,6 +161,8 @@ github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJm
 github.com/blakesmith/ar v0.0.0-20190502131153-809d4375e1fb/go.mod h1:PkYb9DJNAwrSvRx5DYA+gUcOIgTGVMNkfSCbZM8cWpI=
 github.com/blang/semver v3.1.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
+github.com/bmatcuk/doublestar v1.3.4 h1:gPypJ5xD31uhX6Tf54sDPUOBXTqKH4c9aPY66CyQrS0=
+github.com/bmatcuk/doublestar v1.3.4/go.mod h1:wiQtGV+rzVYxB7WIlirSN++5HPtPlXEo9MEoZQC/PmE=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/bombsimon/wsl/v2 v2.0.0/go.mod h1:mf25kr/SqFEPhhcxW1+7pxzGlW+hIl/hYTKY95VwV8U=
 github.com/bombsimon/wsl/v2 v2.2.0/go.mod h1:Azh8c3XGEJl9LyX0/sFC+CKMc7Ssgua0g+6abzXN4Pg=


### PR DESCRIPTION
Updates:
- Update `paths` default to `["Dockerfile", "*.dockerfile"]`, so Docker files in the current directory are loaded (non-recursively)
- `paths` arg is no longer commented out by default
- Add support for `~` expansion in `paths`
- Add support for `**` to support matching recursively
- Remove file extension matching when using wildcards, e.g., if `paths = [ "*" ]`, files not ending in `.dockerfile`, or not named `Dockerfile` will be loaded as well, which would cause a parsing error
- The plugin will still fail to initialize if `paths` is not defined (as a warning to users)