### PR TITLE
Add columns config and inspect in docker_container table

### DIFF
--- a/docs/tables/docker_container.md
+++ b/docs/tables/docker_container.md
@@ -35,3 +35,33 @@ from
 where
   names ? '/practical_austin'
 ```
+
+### List containers which do not have a health check configured
+
+```sql
+select
+  id,
+  names,
+  image,
+  command,
+  created
+from
+  docker_container
+where
+  config -> 'Healthcheck' is null;
+```
+
+### List containers with host network namespace shared
+
+```sql
+select
+  id,
+  names,
+  image,
+  command,
+  created
+from
+  docker_container
+where
+  inspect -> 'HostConfig' ->> 'NetworkMode' = 'host';
+```


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  id,
  names,
  image,
  command,
  created
from
  docker_container
where
  config -> 'Healthcheck' is null;
+------------------------------------------------------------------+----------------------------+------------------------------------------------------------------------------------------
| id                                                               | names                      | image                                                                                    
+------------------------------------------------------------------+----------------------------+------------------------------------------------------------------------------------------
| 914448c39cbae39df8b595d56426c7dbfae488fbcfe5112ec815166bb20272a4 | ["/one_op-connect-api_1"]  | 1password/connect-api:1.6                                                                
| 7d9b1b8720c4180c9dcf8b85a3ebbe803db0e03c1ca5d8b0d074ce69b1810511 | ["/one_op-connect-sync_1"] | 1password/connect-sync:1.6                                                               
| 8a82d2d441e7ed10c3cbc2b4c9b1fe638edd1d46f2d56d5eb71a8f9e220b83f7 | ["/minikube"]              | gcr.io/k8s-minikube/kicbase:v0.0.34@sha256:f2a1e577e43fd6769f35cdb938f6d21c3dacfd763062d1
+------------------------------------------------------------------+----------------------------+------------------------------------------------------------------------------------------
> select
  id,
  names,
  image,
  command,
  created
from
  docker_container
where
  inspect -> 'HostConfig' ->> 'NetworkMode' = 'host';
+----+-------+-------+---------+---------+
| id | names | image | command | created |
+----+-------+-------+---------+---------+
+----+-------+-------+---------+---------+

```
</details>
